### PR TITLE
refactor: rework the ODRL Profile Builder

### DIFF
--- a/examples/build_profile.rb
+++ b/examples/build_profile.rb
@@ -1,26 +1,27 @@
 require 'odrl/profile/builder'
 
 p = ODRL::Profile::Builder.new(
-    uri: 'https://example.org/myprofiles/germplasm_odrl_profile.ttl',
+    uri: "https://example.org/myprofiles/grp",
     title: "ODRL Profile for Germplasm resources",
     description: "There are some properties and comparisons that only make sense in the Germplasm expert domain",
     author: "Mark D Wilkinson",
-    profile_class: "https://example.org/myprofiles/ontology#SeedOffer"
+    version: 0.1,
+    license: "https://creativecommons.org/licenses/by/4.0/"
 )
 
 p.asset_relations << ODRL::Profile::AssetRelation.new( 
-    uri: "https://example.org/myprofiles/ontology#nagoya_permission",
+    uri: "https://example.org/myprofiles/grp#nagoya_permission",
     label: "Permission under Nagoya protocol", 
     definition: "Permission is a special thing in the Nagoya protocol")
 
 
 p.party_functional_roles << ODRL::Profile::PartyFunction.new(  
-    uri: "https://example.org/myprofiles/ontology#nagoya_assigner",
+    uri: "https://example.org/myprofiles/grp#nagoya_assigner",
     label: "Assigner with Nagoya authority to assign", 
     definition: "Assigners have special responsibilities in the Nagoya protocol")
 
 p.actions << ODRL::Profile::Action.new( 
-    uri: "https://example.org/myprofiles/ontology#nagoya_propogate",
+    uri: "https://example.org/myprofiles/grp#nagoya_propogate",
     label: "Plant and Harvest", 
     definition: "the action of planting and harvesting the seed", 
     included_in: ODRLV.use,
@@ -28,17 +29,17 @@ p.actions << ODRL::Profile::Action.new(
 
 
 p.leftOperands << ODRL::Profile::LeftOperand.new( 
-    uri: "https://example.org/myprofiles/ontology#at_risk_species",
+    uri: "https://example.org/myprofiles/grp#at_risk_species",
     label: "At Risk Species", 
     definition: "A species that has been flagged as at-risk of extinction")
 
 p.rightOperands << ODRL::Profile::RightOperand.new( 
-    uri: "https://example.org/myprofiles/ontology#on_watchlist",
+    uri: "https://example.org/myprofiles/grp#on_watchlist",
     label: "On Watchlist", 
     definition: "A species whose risk of extinction is on a watchlist")
 
 p.operators << ODRL::Profile::Operator.new( 
-    uri: "https://example.org/myprofiles/ontology#within_risk_boundary",
+    uri: "https://example.org/myprofiles/grp#within_risk_boundary",
     label: "Within Bounds", 
     definition: "comparison of risk boundaries")
 


### PR DESCRIPTION
The Profile Builder has been refactored to generate correct ODRL profiles as Ontologies with their SKOS members.

- URI has been simplified.
- Profiles can now have a `version`, a `license`, a `prefix` and a `separator` (# or /).
- Custom policies can now be generated.
- Profile elements have now optional `parent_class` and `parent_property` arguments to generate the corresponding `rdfs:subClassOf` and `rdfs:subPropertyOf`.
- Profile Builder has a new `prefixes` attribute that will be used later to add the necessary prefixes.
- The example of profile builder has been refactored according to the above changes/addings.